### PR TITLE
feat: add create-github-repo.sh and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,73 @@
+# create-github-repo.sh
+
+GitHub リポジトリを作成し、ブランチ保護・CODEOWNERS・各種機能を一括設定するスクリプトです。
+
+## 機能
+
+実行すると以下を自動で行います：
+
+1. GitHub CLI でログイン (`gh auth login`)
+2. リポジトリを作成（公開/非公開・説明文を設定可）
+3. `CODEOWNERS` ファイルを追加してプッシュ（全ファイルの変更にオーナー承認を要求）
+4. Discussions・Projects を有効化
+5. `main` ブランチに保護ルールセットを作成
+   - ブランチ削除の禁止
+   - 強制プッシュの禁止
+   - PR マージ前に承認者 1 名必須
+   - コードオーナーのレビュー必須
+   - プッシュ時に古いレビューを無効化
+6. GitHub CLI からログアウト
+
+## 前提条件
+
+- [GitHub CLI (`gh`)](https://cli.github.com/) がインストール済みであること
+- `git` がインストール済みであること
+
+## 使い方
+
+```bash
+# 対話モード（引数なし）
+./create-github-repo.sh
+
+# 引数を指定して実行
+./create-github-repo.sh <REPO_NAME> [DESCRIPTION] [public|private]
+```
+
+### 引数
+
+| 引数 | 説明 | デフォルト |
+|------|------|-----------|
+| `REPO_NAME` | リポジトリ名 | 対話入力 |
+| `DESCRIPTION` | リポジトリの説明（省略可） | 対話入力 |
+| `public\|private` | 公開設定 | 対話入力（デフォルト: `private`） |
+
+### 実行例
+
+```bash
+# リポジトリ名・説明・公開設定をすべて指定
+./create-github-repo.sh my-repo "My description" private
+
+# リポジトリ名のみ指定（他は対話入力）
+./create-github-repo.sh my-repo
+
+# すべて対話入力
+./create-github-repo.sh
+```
+
+## ブランチ保護ルールの詳細
+
+`main` ブランチに以下のルールセット（`Protect main`）が作成されます：
+
+| ルール | 設定 |
+|--------|------|
+| ブランチ削除 | 禁止 |
+| 強制プッシュ | 禁止 |
+| 必要承認者数 | 1 名 |
+| コードオーナーのレビュー | 必須 |
+| プッシュ時に古いレビューを無効化 | 有効 |
+
+## 注意事項
+
+- スクリプト終了時に一時ディレクトリは自動削除されます
+- スクリプト完了後、`gh auth logout` が自動実行されます
+- リポジトリ名は空にできません

--- a/create-github-repo.sh
+++ b/create-github-repo.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# create-github-repo.sh
+# Create a new GitHub repository with branch protection and CODEOWNERS
+# ---------------------------------------------------------------------------
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [REPO_NAME] [DESCRIPTION] [public|private]
+
+Arguments:
+  REPO_NAME     Repository name (interactive if omitted)
+  DESCRIPTION   Repository description (interactive if omitted, empty is OK)
+  public|private  Visibility (interactive if omitted)
+
+Options:
+  -h, --help    Show this help message and exit
+
+Examples:
+  $(basename "$0") my-repo "My description" private
+  $(basename "$0") my-repo
+  $(basename "$0")
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# Parse arguments
+# ---------------------------------------------------------------------------
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  usage
+  exit 0
+fi
+
+ARG_REPO_NAME="${1:-}"
+ARG_DESCRIPTION="${2:-}"
+ARG_VISIBILITY="${3:-}"
+
+# ---------------------------------------------------------------------------
+# Cleanup trap
+# ---------------------------------------------------------------------------
+TMPDIR_PATH=""
+cleanup() {
+  if [[ -n "$TMPDIR_PATH" && -d "$TMPDIR_PATH" ]]; then
+    rm -rf "$TMPDIR_PATH"
+  fi
+}
+trap cleanup EXIT
+
+# ---------------------------------------------------------------------------
+# 1. Authenticate
+# ---------------------------------------------------------------------------
+echo "==> Logging in to GitHub..."
+gh auth login
+
+# ---------------------------------------------------------------------------
+# 2. Get GitHub username
+# ---------------------------------------------------------------------------
+USERNAME=$(gh api user --jq '.login')
+echo "==> Logged in as: $USERNAME"
+
+# ---------------------------------------------------------------------------
+# 3. Collect inputs (args take precedence over interactive)
+# ---------------------------------------------------------------------------
+
+# Repository name (empty is not OK)
+if [[ -n "$ARG_REPO_NAME" ]]; then
+  REPO_NAME="$ARG_REPO_NAME"
+else
+  while true; do
+    read -rp "Repository name: " REPO_NAME
+    if [[ -n "$REPO_NAME" ]]; then
+      break
+    fi
+    echo "Error: Repository name cannot be empty. Please try again."
+  done
+fi
+
+# Description (empty is OK)
+if [[ $# -ge 2 ]]; then
+  DESCRIPTION="$ARG_DESCRIPTION"
+else
+  read -rp "Description (optional): " DESCRIPTION
+fi
+
+# Visibility
+if [[ -n "$ARG_VISIBILITY" ]]; then
+  case "$ARG_VISIBILITY" in
+    public|private)
+      VISIBILITY="$ARG_VISIBILITY"
+      ;;
+    *)
+      echo "Error: Visibility must be 'public' or 'private', got: $ARG_VISIBILITY" >&2
+      exit 1
+      ;;
+  esac
+else
+  while true; do
+    read -rp "Visibility [public/private] (default: private): " VISIBILITY
+    VISIBILITY="${VISIBILITY:-private}"
+    case "$VISIBILITY" in
+      public|private)
+        break
+        ;;
+      *)
+        echo "Error: Please enter 'public' or 'private'."
+        ;;
+    esac
+  done
+fi
+
+echo ""
+echo "==> Creating repository: $USERNAME/$REPO_NAME"
+echo "    Description : ${DESCRIPTION:-<none>}"
+echo "    Visibility  : $VISIBILITY"
+echo ""
+
+# ---------------------------------------------------------------------------
+# 4. Create repository
+# ---------------------------------------------------------------------------
+gh repo create "$USERNAME/$REPO_NAME" \
+  --"$VISIBILITY" \
+  --description "$DESCRIPTION" \
+  --enable-issues
+
+echo "==> Repository created."
+
+# ---------------------------------------------------------------------------
+# 5. Clone → add CODEOWNERS → push
+# ---------------------------------------------------------------------------
+TMPDIR_PATH=$(mktemp -d)
+echo "==> Cloning into $TMPDIR_PATH ..."
+gh repo clone "$USERNAME/$REPO_NAME" "$TMPDIR_PATH"
+
+pushd "$TMPDIR_PATH" > /dev/null
+
+mkdir -p .github
+echo "* @$USERNAME" > .github/CODEOWNERS
+
+git add .github/CODEOWNERS
+git commit -m "chore: add CODEOWNERS to require code review"
+git push -u origin main
+
+popd > /dev/null
+echo "==> CODEOWNERS committed and pushed."
+
+# ---------------------------------------------------------------------------
+# 6. Enable Discussions and Projects
+# ---------------------------------------------------------------------------
+echo "==> Enabling Discussions and Projects..."
+gh repo edit "$USERNAME/$REPO_NAME" \
+  --enable-discussions \
+  --enable-projects
+
+# ---------------------------------------------------------------------------
+# 7. Create branch protection ruleset for main
+# ---------------------------------------------------------------------------
+echo "==> Creating branch protection ruleset for 'main'..."
+gh api "repos/$USERNAME/$REPO_NAME/rulesets" \
+  -X POST \
+  --input - <<EOF
+{
+  "name": "Protect main",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/heads/main"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 1,
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": true,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": false
+      }
+    }
+  ]
+}
+EOF
+
+echo "==> Ruleset created."
+
+# ---------------------------------------------------------------------------
+# 8. Logout and finish
+# ---------------------------------------------------------------------------
+echo "==> Logging out..."
+gh auth logout --hostname github.com
+
+REPO_URL="https://github.com/$USERNAME/$REPO_NAME"
+echo ""
+echo "====================================================="
+echo " Repository created successfully!"
+echo " URL: $REPO_URL"
+echo "====================================================="


### PR DESCRIPTION
## Summary

- GitHub リポジトリの作成・ブランチ保護・CODEOWNERS 設定を一括で行う `create-github-repo.sh` を追加
- スクリプトの使い方・機能説明をまとめた `README.md` を追加

## Test plan

- [x] `./create-github-repo.sh` を対話モードで実行し、リポジトリが正常に作成されることを確認
- [x] 引数指定モードで実行し、正常に動作することを確認
- [x] 作成されたリポジトリに CODEOWNERS・ブランチ保護ルールが設定されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)